### PR TITLE
Add `future` module, release concurrency permit in vacation-spawned task, readme/test improvements, remove default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ description = "Give your (runtime) workers a break!"
 categories = ["asynchronous", "executor"]
 
 [features]
-default = ["tokio"]
-tokio = ["tokio/rt",]
+default = []
+tokio = ["tokio/rt"]
 
 [dependencies]
 log = "0.4.22"
@@ -21,9 +21,9 @@ num_cpus = "1.0"
 tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"]}
-futures-util = "0.3.31"
+futures-util = "0.3"
 rayon = "1"
+tokio = { version = "1", features = ["full"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ categories = ["asynchronous", "executor"]
 
 [features]
 default = []
+future = ["pin-project-lite"]
 tokio = ["tokio/rt"]
 
 [dependencies]
 log = "0.4.22"
 num_cpus = "1.0"
+pin-project-lite = { version = "0.2.15", optional = true }
 tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # vacation
- Vacation: Give your (runtime) workers a break! 
+Vacation: Give your (runtime) workers a break!
+
+Better handling for compute-heavy segments of work that might block your async worker threads.
  
 ## Overview
-
-Today, when library authors write async APIs, they don't have a good way to handle long-running sync segments.
+When library authors write async APIs, they by default don't have a good way to handle long-running sync segments.
 
 An application author can use selective handling such as `tokio::task::spawn_blocking()` along with concurrency control to delegate sync segments to blocking threads. Or, they might send the work to a `rayon` threadpool.
 
@@ -15,11 +16,14 @@ This library solves this problem by providing libray authors a static, globally 
 And then, the applications using the library can tune handling based on their preferred approach.
 
 ## Usage - Library Authors
-For library authors, it's as simple as adding a dependency enabling `vacation` (perhaps behind a feature flag).
+### When working with async/await
+The simplest way for a library author to use this library is by delegating
+work via [`execute()`] and awaiting it.
 
+This requires no feature flags:
 ```ignore
 [dependencies]
-vacation = { version = "0.1", default-features = false }
+vacation = "0.1"
 ```
 
 And then wrap any sync work by passing it as a closure to a global `execute()` call:
@@ -35,26 +39,52 @@ pub async fn a_future_that_has_blocking_sync_work() -> u8 {
     // block the current worker thread
     vacation::execute(move || { sync_work("foo".to_string()) }, vacation::ChanceOfBlocking::High).await.unwrap()
 }
-
 ```
 
+### Integrating with manually implemented futures
+If your library is instead manually implementing the [`std::future::Future`] trait, you might instead
+want to enable the `future` feature flag:
+
+```ignore
+[dependencies]
+vacation = { version = "0.1", features = ["future"] }
+```
+
+This enables the [`future::FutureBuilder`] api along with the two types of `Vacation` futures it can generate:
+- [`future::OffloadFirst`] - delegate work to vacation, and then process the results into an inner future and poll the inner future to completion
+- [`future::OffloadWithFuture`] - poll the inner future, while also using a callback to retrieve any vacation work and polling it alongisde the inner future 
+
 ## Usage - Application owners
-Application authors will need to add this library as a a direct dependency in order to customize the execution strategy.
-By default, the strategy is just a non-op.
+Application authors will need to add this library as a a direct dependency in order to customize the execution strategy
+beyond the default no-op.
+
+Application authors can also call [`execute()`] if there are application-layer compute-heavy segments in futures.
 
 ### Simple example
 
 ```ignore
 [dependencies]
-// enables `tokio` feature by default which allows the spawn_blocking strategy
-vacation = { version = "0.1" }
+# tokio feature adds the spawn_blocking executor
+vacation = { version = "0.1", features = ["tokio"] }
 ```
 
 And then call the `install_tokio_strategy()` helper that uses some sensible defaults (spawn blocking w/ concurrency control equal to cpu cores):
 ```
 #[tokio::main]
 async fn main() {
+# #[cfg(feature="tokio")]
+#  {
     vacation::install_tokio_strategy().unwrap();
+
+    // if wanting to delegate work to vacation:
+    let vacation_future = vacation::execute(|| {
+        // represents compute heavy work
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        5
+    }, vacation::ChanceOfBlocking::High);
+    
+    assert_eq!(vacation_future.await.unwrap(), 5);
+#    }
 }
 ```
 
@@ -62,14 +92,17 @@ async fn main() {
 To customize a bit more, you can select from a cookie cutter strategy and configure concurrency, via `vacation::init()`:
 ```ignore
 [dependencies]
-// enables `tokio` feature by default which allows the spawn_blocking strategy
-vacation = { version = "0.1" }
+# tokio feature adds spawn_blocking executor
+vacation = { version = "0.1", features = ["tokio"] }
 ```
 
 ```
 #[tokio::main]
 async fn main() {
+# #[cfg(feature="tokio")]
+# {
     vacation::init().max_concurrency(5).spawn_blocking().install();
+# }
 }
 ```
 
@@ -78,7 +111,7 @@ Or, you can add an alternate strategy, for instance a custom closure using Rayon
 
 ```ignore
 [dependencies]
-vacation = { version = "0.1", default-features = false }
+vacation = "0.1"
 // used for example with custom executor
 rayon = "1"
 ```
@@ -102,3 +135,12 @@ fn initialize_strategy() {
         .custom_executor(custom_closure).install().unwrap();
 }
 ```
+
+## Feature flags
+
+This library uses feature flags to reduce the dependency tree and amount of compiled code. Feature enablement does not change any runtime behavior
+without corresponding code calling the feature-gated APIs.
+
+The features are:
+- `tokio` - enables the [`ExecutorStrategy::SpawnBlocking`] strategy, which is a version of tokio's `spawn_blocking` with concurrency control baked in
+- `future` - wrapper future types, intended for library authors that have manual future implementations

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fn sync_work(input: String)-> u8 {
 pub async fn a_future_that_has_blocking_sync_work() -> u8 {
     // relies on application-specified strategy for translating execute into a future that won't
     // block the current worker thread
-    vacation::execute(move || { sync_work("foo".to_string()) }, vacation::ChanceOfBlocking::High).await.unwrap()
+    vacation::execute(move || { sync_work("foo".to_string()) }, vacation::ChanceOfBlocking::High, "example.operation").await.unwrap()
 }
 ```
 
@@ -81,7 +81,7 @@ async fn main() {
         // represents compute heavy work
         std::thread::sleep(std::time::Duration::from_millis(500));
         5
-    }, vacation::ChanceOfBlocking::High);
+    }, vacation::ChanceOfBlocking::High, "example.operation");
     
     assert_eq!(vacation_future.await.unwrap(), 5);
 #    }
@@ -125,8 +125,8 @@ static THREADPOOL: OnceLock<ThreadPool> = OnceLock::new();
 fn initialize_strategy() {
     THREADPOOL.set(rayon::ThreadPoolBuilder::default().build().unwrap());
 
-    let custom_closure = |f: vacation::CustomClosureInput| {
-        Box::new(async move { Ok(THREADPOOL.get().unwrap().spawn(f)) }) as vacation::CustomClosureOutput
+    let custom_closure = |input: vacation::CustomClosureInput| {
+        Box::new(async move { Ok(THREADPOOL.get().unwrap().spawn(input.work)) }) as vacation::CustomClosureOutput
     };
 
     vacation::init()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::ExecutorStrategy;
 
 /// An error from the custom executor
@@ -19,8 +17,8 @@ pub enum Error {
     JoinError(tokio::task::JoinError),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::AlreadyInitialized(strategy) => write!(
                 f,

--- a/src/executor/custom.rs
+++ b/src/executor/custom.rs
@@ -2,8 +2,6 @@ use std::future::Future;
 
 use crate::{concurrency_limit::ConcurrencyLimit, error::Error};
 
-use super::Execute;
-
 /// The input for the custom closure
 pub type CustomClosureInput = Box<dyn FnOnce() + Send + 'static>;
 /// The output type for the custom closure
@@ -28,13 +26,11 @@ impl Custom {
             concurrency_limit: ConcurrencyLimit::new(max_concurrency),
         }
     }
-}
 
-impl Execute for Custom {
     // the compiler correctly is pointing out that the custom closure isn't guaranteed to call f.
     // but, we leave that to the implementer to guarantee since we are limited by working with static signatures
     #[allow(unused_variables)]
-    async fn execute<F, R>(&self, f: F) -> Result<R, Error>
+    pub(crate) async fn execute<F, R>(&self, f: F) -> Result<R, Error>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,

--- a/src/executor/execute_directly.rs
+++ b/src/executor/execute_directly.rs
@@ -1,7 +1,5 @@
 use crate::{concurrency_limit::ConcurrencyLimit, error::Error};
 
-use super::Execute;
-
 pub(crate) struct ExecuteDirectly {
     concurrency_limit: ConcurrencyLimit,
 }
@@ -12,10 +10,8 @@ impl ExecuteDirectly {
             concurrency_limit: ConcurrencyLimit::new(max_concurrency),
         }
     }
-}
 
-impl Execute for ExecuteDirectly {
-    async fn execute<F, R>(&self, f: F) -> Result<R, Error>
+    pub(crate) async fn execute<F, R>(&self, f: F) -> Result<R, Error>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -8,7 +8,7 @@ use std::{future::Future, sync::OnceLock};
 use custom::{Custom, CustomClosure};
 use execute_directly::ExecuteDirectly;
 
-use crate::{init, Error, ExecutorStrategy, GlobalStrategy};
+use crate::{Error, ExecutorStrategy, GlobalStrategy};
 
 pub(crate) trait Execute {
     /// Accepts a sync function and processes it to completion.
@@ -46,11 +46,6 @@ fn set_global_strategy(strategy: Executor) -> Result<(), Error> {
 /// };
 ///
 /// # fn run() {
-///
-/// #[cfg(feature = "tokio")]
-/// assert_eq!(global_strategy(), GlobalStrategy::Default(ExecutorStrategy::SpawnBlocking));
-///
-/// #[cfg(not(feature = "tokio"))]
 /// assert_eq!(global_strategy(), GlobalStrategy::Default(ExecutorStrategy::ExecuteDirectly));
 ///
 /// vacation::init()
@@ -153,7 +148,7 @@ impl From<&Executor> for ExecutorStrategy {
 /// ```
 #[cfg(feature = "tokio")]
 pub fn install_tokio_strategy() -> Result<(), Error> {
-    init()
+    super::init()
         .max_concurrency(num_cpus::get())
         .spawn_blocking()
         .install()
@@ -166,8 +161,11 @@ pub fn install_tokio_strategy() -> Result<(), Error> {
 ///
 /// ```
 /// # fn run() {
+///
+/// let cores = num_cpus::get();
+///
 /// vacation::init()
-///         .max_concurrency(10)
+///         .max_concurrency(cores)
 ///         .execute_directly()
 ///         .install()
 ///         .unwrap();

--- a/src/executor/spawn_blocking.rs
+++ b/src/executor/spawn_blocking.rs
@@ -29,9 +29,12 @@ impl Execute for SpawnBlocking {
         let _permit = self.concurrency_limit.acquire_permit().await;
 
         self.handle
-            .spawn_blocking(f)
+            .spawn_blocking(move || {
+                let _permit = _permit;
+                f()
+                // permit implicitly drops after spawned work finishes
+            })
             .await
             .map_err(Error::JoinError)
-        // permit implicitly drops
     }
 }

--- a/src/executor/spawn_blocking.rs
+++ b/src/executor/spawn_blocking.rs
@@ -2,8 +2,6 @@ use tokio::runtime::Handle;
 
 use crate::{concurrency_limit::ConcurrencyLimit, error::Error};
 
-use super::Execute;
-
 pub(crate) struct SpawnBlocking {
     concurrency_limit: ConcurrencyLimit,
     handle: Handle,
@@ -18,10 +16,8 @@ impl SpawnBlocking {
             handle,
         }
     }
-}
 
-impl Execute for SpawnBlocking {
-    async fn execute<F, R>(&self, f: F) -> Result<R, Error>
+    pub(crate) async fn execute<F, R>(&self, f: F) -> Result<R, Error>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,

--- a/src/future/first.rs
+++ b/src/future/first.rs
@@ -1,0 +1,404 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+
+use super::{
+    FutureBuilder, HasIncorporateFn, NeedsIncorporateFn, NeedsOffload, NoInnerFuture,
+    OffloadFirstStrat, WhileWaitingMode,
+};
+
+pin_project! {
+/// Initialize the inner future after executing a single piece of work with vacation.
+/// That work should output return inputs necessary to construct the inner future.
+///
+/// Continue polling the inner future as a pass-through after initialization.
+///
+/// # Examples
+/// ```
+/// # #[tokio::main]
+/// # async fn main() {
+/// let future = vacation::future::builder()
+///         .offload_first(
+///             vacation::future::OffloadFirst::builder()
+///                 .offload_future(vacation::execute(
+///                      // the work to offload
+///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
+///                     vacation::ChanceOfBlocking::High
+///                 ))
+///                 // accepts the result of offloaded work, and returns an erorr
+///                 // or an inner future
+///                 .incorporate_fn(|res| {
+///                     // vacation work returned an executor error
+///                     if let Err(err) = res {
+///                         return Err(false);
+///                     }
+///                     Ok(Box::pin(async move {
+///                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+///                         true
+///                     }))
+///                 })
+///          )
+///         .build();
+///
+/// assert_eq!(future.await, true)
+/// # }
+/// ```
+pub struct OffloadFirstFuture<InnerFut, OffloadResult, IncorporateFn> {
+    inner: Inner<InnerFut, OffloadResult, IncorporateFn>
+}
+}
+
+enum Inner<InnerFut, OffloadResult, IncorporateFn> {
+    OffloadInProgress {
+        offload_fut: Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>,
+        incorporate: Incorporate<IncorporateFn>,
+    },
+    InnerFuture {
+        inner_fut: InnerFut,
+    },
+}
+
+/// The incorporate function passed via [`incorporate_fn()`].
+///
+/// Takes output of vacation work and generates inner future
+///
+/// [`incorporate_fn()`]: crate::future::first::OffloadFirst::incorporate_fn()
+#[derive(Debug)]
+pub enum Incorporate<IncorporateFn> {
+    /// Vacation work still pending
+    Incorporate(IncorporateFn),
+    /// Transitional state used while resolving
+    Consumed,
+}
+
+/// A sub-builder for the work to be offloaded via [`OffloadFirstFuture`]
+///
+/// Use [`OffloadFirst::builder()`] to construct it.
+///
+/// [`OffloadFirst::builder()`]: crate::future::first::OffloadFirst::builder()
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+#[derive(Debug)]
+pub struct OffloadFirst<OffloadFuture, IncorporateFn> {
+    offload_future: OffloadFuture,
+    incorporate_fn: IncorporateFn,
+}
+
+/// Needs input work to execute via vacation
+#[derive(Debug)]
+pub struct NeedsOffloadFuture;
+/// Has work ready to execute via vacation
+pub struct HassOffloadFuture<OffloadResult>(
+    Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>,
+);
+
+impl<OffloadResult> std::fmt::Debug for HassOffloadFuture<OffloadResult> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("HassOffloadFuture").finish()
+    }
+}
+
+impl OffloadFirst<NeedsOffloadFuture, NeedsIncorporateFn> {
+    /// A sub-builder for the work to be offloaded via [`OffloadFirstFuture`]
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    ///   let sub_builder = vacation::future::OffloadFirst::builder()
+    ///                 .offload_future(vacation::execute(
+    ///                      // the work to offload
+    ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
+    ///                     vacation::ChanceOfBlocking::High
+    ///                 ))
+    ///                 // accepts the result of offloaded work, and returns an erorr
+    ///                 // or an inner future
+    ///                 .incorporate_fn(|res: Result<(), vacation::Error>| {
+    ///                     // vacation work returned an executor error
+    ///                     if let Err(err) = res {
+    ///                         return Err(false);
+    ///                     }   
+    ///                     Ok(Box::pin(async move {
+    ///                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    ///                         true
+    ///                     }))
+    ///                 });
+    /// # }
+    /// ```
+    /// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+    #[must_use = "doesn't do anything unless built"]
+    pub fn builder() -> OffloadFirst<NeedsOffloadFuture, NeedsIncorporateFn> {
+        OffloadFirst {
+            offload_future: NeedsOffloadFuture,
+            incorporate_fn: NeedsIncorporateFn,
+        }
+    }
+}
+
+impl<IncorporateFn> OffloadFirst<NeedsOffloadFuture, IncorporateFn> {
+    /// The future to offload via vacation. Results of this are processed
+    /// via the input to [`incorporate_fn()`]
+    ///
+    /// [`incorporate_fn()`]: crate::future::first::OffloadFirst::incorporate_fn()
+    #[must_use = "doesn't do anything unless built"]
+    pub fn offload_future<OffloadResult>(
+        self,
+        offload_future: impl Future<Output = Result<OffloadResult, crate::Error>> + Send + 'static,
+    ) -> OffloadFirst<HassOffloadFuture<OffloadResult>, IncorporateFn>
+    where
+        OffloadResult: Send + 'static,
+    {
+        OffloadFirst {
+            offload_future: HassOffloadFuture(Box::new(Box::pin(offload_future))),
+            incorporate_fn: self.incorporate_fn,
+        }
+    }
+}
+
+impl<OffloadFuture> OffloadFirst<OffloadFuture, NeedsIncorporateFn> {
+    /// Process the output of the offloaded work, along with any other state
+    /// owned by this closure, and generate the inner future.
+    #[must_use = "doesn't do anything unless built"]
+    pub fn incorporate_fn<IncorporateFn, OffloadResult, InnerFut>(
+        self,
+        incorporate_fn: IncorporateFn,
+    ) -> OffloadFirst<OffloadFuture, HasIncorporateFn<IncorporateFn>>
+    where
+        IncorporateFn:
+            FnOnce(Result<OffloadResult, crate::Error>) -> Result<InnerFut, InnerFut::Output>,
+        OffloadResult: Send + 'static,
+        InnerFut: Future + Unpin,
+    {
+        OffloadFirst {
+            offload_future: self.offload_future,
+            incorporate_fn: HasIncorporateFn(incorporate_fn),
+        }
+    }
+}
+
+impl<Strategy, InnerFuture, WhileWaiting>
+    FutureBuilder<Strategy, InnerFuture, NeedsOffload, WhileWaiting>
+{
+    /// Initialize the inner future after executing a single piece of work with vacation.
+    /// That work should output return inputs necessary to construct the inner future.
+    ///
+    /// Continue polling the inner future as a pass-through after initialization.
+    ///
+    /// # Examples
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let future = vacation::future::builder()
+    ///         .offload_first(
+    ///             vacation::future::OffloadFirst::builder()
+    ///                 .offload_future(vacation::execute(
+    ///                      // the work to offload
+    ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
+    ///                     vacation::ChanceOfBlocking::High
+    ///                 ))
+    ///                 // accepts the result of offloaded work, and returns an erorr
+    ///                 // or an inner future
+    ///                 .incorporate_fn(|res| {
+    ///                     // vacation work returned an executor error
+    ///                     if let Err(err) = res {
+    ///                         return Err(false);
+    ///                     }
+    ///                     Ok(Box::pin(async move {
+    ///                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    ///                         true
+    ///                     }))
+    ///                 })
+    ///          )
+    ///         .build();
+    ///
+    /// assert_eq!(future.await, true)
+    /// # }
+    /// ```
+    #[must_use = "doesn't do anything unless built"]
+    pub fn offload_first<InnerFut, OffloadResult, IncorporateFn>(
+        self,
+        offload: OffloadFirst<HassOffloadFuture<OffloadResult>, HasIncorporateFn<IncorporateFn>>,
+    ) -> FutureBuilder<
+        OffloadFirstStrat,
+        NoInnerFuture,
+        OffloadFirst<HassOffloadFuture<OffloadResult>, HasIncorporateFn<IncorporateFn>>,
+        WhileWaitingMode,
+    >
+    where
+        IncorporateFn:
+            FnOnce(Result<OffloadResult, crate::Error>) -> Result<InnerFut, InnerFut::Output>,
+        OffloadResult: Send + 'static,
+        InnerFut: Future + Unpin,
+    {
+        FutureBuilder::<
+            OffloadFirstStrat,
+            NoInnerFuture,
+            OffloadFirst<HassOffloadFuture<OffloadResult>, HasIncorporateFn<IncorporateFn>>,
+            WhileWaitingMode,
+        > {
+            strategy: OffloadFirstStrat,
+            inner_fut: NoInnerFuture,
+            offload,
+            while_waiting: WhileWaitingMode::SuppressInnerPoll,
+        }
+    }
+}
+
+impl<IncorporateFn, OffloadResult>
+    FutureBuilder<
+        OffloadFirstStrat,
+        NoInnerFuture,
+        OffloadFirst<HassOffloadFuture<OffloadResult>, HasIncorporateFn<IncorporateFn>>,
+        WhileWaitingMode,
+    >
+{
+    #[must_use = "doesn't do anything unless polled"]
+    /// Finish building [`OffloadFirstFuture`]
+    pub fn build<InnerFut>(self) -> OffloadFirstFuture<InnerFut, OffloadResult, IncorporateFn>
+    where
+        IncorporateFn:
+            FnOnce(Result<OffloadResult, crate::Error>) -> Result<InnerFut, InnerFut::Output>,
+        OffloadResult: Send + 'static,
+        InnerFut: Future + Unpin,
+    {
+        let inner: Inner<InnerFut, OffloadResult, IncorporateFn> = Inner::OffloadInProgress {
+            offload_fut: self.offload.offload_future.0,
+            incorporate: Incorporate::Incorporate(self.offload.incorporate_fn.0),
+        };
+
+        OffloadFirstFuture { inner }
+    }
+}
+
+impl<InnerFut, OffloadResult, IncorporateFn> Future
+    for OffloadFirstFuture<InnerFut, OffloadResult, IncorporateFn>
+where
+    InnerFut: Future + Unpin,
+    OffloadResult: Send + 'static,
+    IncorporateFn:
+        FnOnce(Result<OffloadResult, crate::Error>) -> Result<InnerFut, InnerFut::Output>,
+{
+    type Output = InnerFut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match &mut this.inner {
+            // we've already finished our startup vacation work, just poll inner
+            Inner::InnerFuture { ref mut inner_fut } => Pin::new(inner_fut).as_mut().poll(cx),
+            // vacation startup work still ongoing
+            Inner::OffloadInProgress {
+                ref mut offload_fut,
+                ref mut incorporate,
+            } => {
+                // drive vacation work to completion
+                let res = ready!(Pin::new(offload_fut).as_mut().poll(cx));
+
+                // consume the incorporate
+                let incorporate = match std::mem::replace(incorporate, Incorporate::Consumed) {
+                    Incorporate::Incorporate(incorporate) => incorporate,
+                    Incorporate::Consumed => {
+                        panic!("offload first work can only finish and be incorporated once")
+                    }
+                };
+
+                // incorporate offloaded work result into inner future
+                match (incorporate)(res) {
+                    Ok(mut inner_fut) => {
+                        // poll inner future once
+                        match Pin::new(&mut inner_fut).poll(cx) {
+                            // inner future is done, return it
+                            Poll::Ready(res) => Poll::Ready(res),
+                            Poll::Pending => {
+                                // otherwise the inner future already registered its wakers this past poll
+                                this.inner = Inner::InnerFuture { inner_fut };
+                                Poll::Pending
+                            }
+                        }
+                    }
+                    // if the incorporate fn returns an error, bubble it up
+                    Err(err) => Poll::Ready(err),
+                }
+            }
+        }
+    }
+}
+
+// these tests all use the default executor which is `ExecuteDirectly`
+#[cfg(test)]
+mod test {
+    use crate::{
+        future::test::{TestFuture, TestFutureResponse},
+        ChanceOfBlocking,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_works() {
+        let mut inner_fut = TestFuture::new(3);
+
+        let future = crate::future::builder()
+            .offload_first(
+                OffloadFirst::builder()
+                    .offload_future(crate::execute(move || false, ChanceOfBlocking::High))
+                    .incorporate_fn(move |res| {
+                        Ok(Box::pin(async move {
+                            if res.unwrap() {
+                                inner_fut.error_after(0);
+                            }
+                            inner_fut.await
+                        }))
+                    }),
+            )
+            .build();
+
+        let res = future.await;
+        // polled inner 3 times since we had 3 inner work units
+        assert_eq!(res, TestFutureResponse::Success(3));
+    }
+
+    #[tokio::test]
+    async fn inner_fut_fails() {
+        let mut inner_fut = TestFuture::new(3);
+
+        let future = crate::future::builder()
+            .offload_first(
+                OffloadFirst::builder()
+                    .offload_future(crate::execute(move || true, ChanceOfBlocking::High))
+                    .incorporate_fn(move |res| {
+                        Ok(Box::pin(async move {
+                            if res.unwrap() {
+                                inner_fut.error_after(0);
+                            }
+                            inner_fut.await
+                        }))
+                    }),
+            )
+            .build();
+
+        let res = future.await;
+        // first poll fails
+        assert_eq!(res, TestFutureResponse::InnerError(1));
+    }
+
+    #[tokio::test]
+    async fn vacation_fails() {
+        let future = crate::future::builder()
+            .offload_first(
+                OffloadFirst::builder()
+                    .offload_future(crate::execute(|| {}, ChanceOfBlocking::High))
+                    .incorporate_fn(move |_res: Result<(), crate::Error>| {
+                        Err(TestFutureResponse::VacationIncorporateError)
+                    }),
+            )
+            .build::<TestFuture>();
+
+        let res = future.await;
+        assert_eq!(res, TestFutureResponse::VacationIncorporateError);
+    }
+}

--- a/src/future/first.rs
+++ b/src/future/first.rs
@@ -27,7 +27,8 @@ pin_project! {
 ///                 .offload_future(vacation::execute(
 ///                      // the work to offload
 ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
-///                     vacation::ChanceOfBlocking::High
+///                     vacation::ChanceOfBlocking::High,
+///                     "test.operation"
 ///                 ))
 ///                 // accepts the result of offloaded work, and returns an erorr
 ///                 // or an inner future
@@ -113,7 +114,8 @@ impl OffloadFirst<NeedsOffloadFuture, NeedsIncorporateFn> {
     ///                 .offload_future(vacation::execute(
     ///                      // the work to offload
     ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
-    ///                     vacation::ChanceOfBlocking::High
+    ///                     vacation::ChanceOfBlocking::High,
+    ///                     "test.operation"
     ///                 ))
     ///                 // accepts the result of offloaded work, and returns an erorr
     ///                 // or an inner future
@@ -198,7 +200,8 @@ impl<Strategy, InnerFuture, WhileWaiting>
     ///                 .offload_future(vacation::execute(
     ///                      // the work to offload
     ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
-    ///                     vacation::ChanceOfBlocking::High
+    ///                     vacation::ChanceOfBlocking::High,
+    ///                     "test.operation"
     ///                 ))
     ///                 // accepts the result of offloaded work, and returns an erorr
     ///                 // or an inner future
@@ -345,7 +348,11 @@ mod test {
         let future = crate::future::builder()
             .offload_first(
                 OffloadFirst::builder()
-                    .offload_future(crate::execute(move || false, ChanceOfBlocking::High))
+                    .offload_future(crate::execute(
+                        move || false,
+                        ChanceOfBlocking::High,
+                        "test.operation",
+                    ))
                     .incorporate_fn(move |res| {
                         Ok(Box::pin(async move {
                             if res.unwrap() {
@@ -369,7 +376,11 @@ mod test {
         let future = crate::future::builder()
             .offload_first(
                 OffloadFirst::builder()
-                    .offload_future(crate::execute(move || true, ChanceOfBlocking::High))
+                    .offload_future(crate::execute(
+                        move || true,
+                        ChanceOfBlocking::High,
+                        "test.operation",
+                    ))
                     .incorporate_fn(move |res| {
                         Ok(Box::pin(async move {
                             if res.unwrap() {
@@ -391,7 +402,11 @@ mod test {
         let future = crate::future::builder()
             .offload_first(
                 OffloadFirst::builder()
-                    .offload_future(crate::execute(|| {}, ChanceOfBlocking::High))
+                    .offload_future(crate::execute(
+                        || {},
+                        ChanceOfBlocking::High,
+                        "test.operation",
+                    ))
                     .incorporate_fn(move |_res: Result<(), crate::Error>| {
                         Err(TestFutureResponse::VacationIncorporateError)
                     }),

--- a/src/future/first.rs
+++ b/src/future/first.rs
@@ -54,7 +54,7 @@ pub struct OffloadFirstFuture<InnerFut, OffloadResult, IncorporateFn> {
 
 enum Inner<InnerFut, OffloadResult, IncorporateFn> {
     OffloadInProgress {
-        offload_fut: Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>,
+        offload_fut: Pin<Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Send>>,
         incorporate: Incorporate<IncorporateFn>,
     },
     InnerFuture {
@@ -92,7 +92,7 @@ pub struct OffloadFirst<OffloadFuture, IncorporateFn> {
 pub struct NeedsOffloadFuture;
 /// Has work ready to execute via vacation
 pub struct HassOffloadFuture<OffloadResult>(
-    Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>,
+    Pin<Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Send>>,
 );
 
 impl<OffloadResult> std::fmt::Debug for HassOffloadFuture<OffloadResult> {
@@ -153,7 +153,7 @@ impl<IncorporateFn> OffloadFirst<NeedsOffloadFuture, IncorporateFn> {
         OffloadResult: Send + 'static,
     {
         OffloadFirst {
-            offload_future: HassOffloadFuture(Box::new(Box::pin(offload_future))),
+            offload_future: HassOffloadFuture(Box::pin(offload_future)),
             incorporate_fn: self.incorporate_fn,
         }
     }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -1,0 +1,281 @@
+/// Contains [`OffloadFirstFuture`], used to resolve one round of compute-heavy work with vacation, and then construct and poll an inner future
+///
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+pub mod first;
+/// Contains [`OffloadWithFuture`], for retrieving and running vacation work alongside polling an inner future
+///
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+pub mod with;
+
+pub use first::{OffloadFirst, OffloadFirstFuture};
+pub use with::{OffloadWith, OffloadWithFuture};
+
+/// Needs a call to [`future()`] (for [`OffloadWithFuture`])
+/// or [`offload_first()`] (for [`OffloadFirstFuture`])
+///
+/// [`future()`]: crate::future::FutureBuilder::future()
+/// [`offload_first()`]: crate::future::FutureBuilder::offload_first()
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+#[derive(Debug)]
+pub struct NeedsStrategy;
+/// Builder will construct [`OffloadFirstFuture`]
+///
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+#[derive(Debug)]
+pub struct OffloadFirstStrat;
+/// Builder will construct [`OffloadWithFuture`]
+///
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+#[derive(Debug)]
+pub struct OffloadWithFutureStrat;
+
+/// Needs a call to [`future()`] (for [`OffloadWithFuture`])
+/// or [`offload_first()`] (for [`OffloadFirstFuture`])
+///
+/// [`future()`]: crate::future::FutureBuilder::future()
+/// [`offload_first()`]: crate::future::FutureBuilder::offload_first()
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+#[derive(Debug)]
+pub struct NeedsInnerFuture;
+/// Builder will construct [`OffloadFirstFuture`], which does not wrap a future
+/// directly.
+///
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+
+#[derive(Debug)]
+pub struct NoInnerFuture;
+
+/// Builder needs a call to [`offload_with()`] or [`offload_first()`]
+///
+/// [`offload_with()`]: crate::future::FutureBuilder::offload_with()
+/// [`offload_first()`]: crate::future::FutureBuilder::offload_first()
+#[derive(Debug)]
+pub struct NeedsOffload;
+
+/// Sub-builder needs a call to [`OffloadWith::incorporate_fn()`]
+/// or [`OffloadFirst::incorporate_fn()`]
+///
+///  [`OffloadWith::incorporate_fn()`]: crate::future::with::OffloadWith::incorporate_fn()
+/// [`OffloadFirst::incorporate_fn()`]: crate::future::first::OffloadFirst::incorporate_fn()
+#[derive(Debug)]
+pub struct NeedsIncorporateFn;
+/// Sub-builder has an incorporate function loaded
+#[derive(Debug)]
+pub struct HasIncorporateFn<IncorporateFn>(IncorporateFn);
+
+/// Builder needs to know whether it should poll the inner future
+/// while offloaded vacation work is ongoing, or wait until that offloaded
+/// work completes.
+///
+/// Use [`FutureBuilder::while_waiting_for_offload()`] to specify.
+///
+/// [`FutureBuilder::while_waiting_for_offload()`]: crate::future::FutureBuilder::while_waiting_for_offload()
+#[derive(Debug)]
+pub struct NeedsWhileWaiting;
+
+/// A builder struct with which to construct [`OffloadFirst`] or [`OffloadWithFuture`] futures.
+///
+/// Start with [`vacation::future::builder()`].
+///
+/// [`OffloadFirst`]: crate::future::first::OffloadFirst
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+/// [`vacation::future::builder()`]: crate::future::builder()
+#[derive(Debug)]
+pub struct FutureBuilder<Strategy, InnerFut, Offload, WhileWaiting> {
+    strategy: Strategy,
+    inner_fut: InnerFut,
+    offload: Offload,
+    while_waiting: WhileWaiting,
+}
+
+/// The mode to use when offload work is active in vacation.
+///
+/// Either skip polling the inner until vacation work is complete,
+/// or continue polling the inner future alongside
+/// the vacation future.
+///
+/// If using [`WhileWaitingMode::SuppressInnerPoll`], note that there is a deadlock risk of the offloaded
+/// work completion relies on the inner future making progress.
+#[derive(PartialEq, Debug)]
+pub enum WhileWaitingMode {
+    /// Skip polling the inner future as long as there is vacation work outstanding
+    ///
+    ///  Note that there is a deadlock risk of the offloaded
+    /// work completion relies on the inner future making progress.
+    SuppressInnerPoll,
+    /// Continue polling the inner future while there is vacation work active.
+    PassThroughInnerPoll,
+}
+
+/// Get a builder that constructs a [`OffloadFirstFuture`] or [`OffloadWithFuture`] wrapper future
+///
+/// # Examples
+///
+/// ## OffloadFirstFuture
+/// ```
+/// # #[tokio::main]
+/// # async fn main() {
+/// let future = vacation::future::builder()
+///         .offload_first(
+///             vacation::future::OffloadFirst::builder()
+///                 .offload_future(vacation::execute(
+///                      // the work to offload
+///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
+///                     vacation::ChanceOfBlocking::High
+///                 ))
+///                 // accepts the result of offloaded work, and returns an erorr
+///                 // or an inner future
+///                 .incorporate_fn(|res| {
+///                     // vacation work returned an executor error
+///                     if let Err(err) = res {
+///                         return Err(false);
+///                     }   
+///                     Ok(Box::pin(async move {
+///                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+///                         true
+///                     }))
+///                 })
+///          )
+///         .build();
+///
+/// assert_eq!(future.await, true)
+/// # }
+/// ```
+///
+///  ## OffloadWith
+///
+/// ```
+/// # #[tokio::main]
+/// # async fn main() {
+/// let future = vacation::future::builder()
+///          // the wrapped future
+///         .future(Box::pin( async move {
+///             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+///             true
+///         }))
+///         .offload_with(
+///             vacation::future::OffloadWith::builder()
+///                 // take a mutable reference to inner future,
+///                 // and retrieve any work to offload
+///                 .get_offload_fn(|_inner_fut| {
+///                     // it could be conditional, but here it's always returning work
+///                     Ok(Some(Box::new(Box::pin(vacation::execute(
+///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
+///                         vacation::ChanceOfBlocking::High
+///                     )))))
+///                 })
+///                 // called with the results of the offloaded work and the inner future,
+///                 // use to convert errors or do any post-processing
+///                 .incorporate_fn(|_inner_fut, res| {
+///                     println!("work complete: {res:#?}");
+///                     Ok(())
+///                 })
+///         )
+///         // could also suppress the inner poll
+///         .while_waiting_for_offload(vacation::future::WhileWaitingMode::PassThroughInnerPoll)
+///         .build();
+///
+/// assert_eq!(future.await, true)
+/// # }
+/// ```
+///
+/// [`OffloadFirstFuture`]: crate::future::first::OffloadFirstFuture
+/// [`OffloadWithFuture`]: crate::future::with::OffloadWithFuture
+#[must_use = "doesn't do anything unless built"]
+pub fn builder() -> FutureBuilder<NeedsStrategy, NeedsInnerFuture, NeedsOffload, NeedsWhileWaiting>
+{
+    FutureBuilder {
+        strategy: NeedsStrategy,
+        inner_fut: NeedsInnerFuture,
+        offload: NeedsOffload,
+        while_waiting: NeedsWhileWaiting,
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    #[derive(PartialEq)]
+    pub(crate) enum TestFutureResponse {
+        Success(usize),
+        InnerError(usize),
+        VacationGetError,
+        VacationWorkError,
+        VacationIncorporateError,
+        ExecutorError,
+    }
+
+    impl std::fmt::Debug for TestFutureResponse {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success(arg0) => f.debug_tuple("Success").field(arg0).finish(),
+                Self::InnerError(arg0) => f.debug_tuple("InnerError").field(arg0).finish(),
+                Self::VacationGetError => write!(f, "VacationGetError"),
+                Self::VacationWorkError => write!(f, "VacationWorkError"),
+                Self::VacationIncorporateError => write!(f, "VacationIncorporateError"),
+                Self::ExecutorError => write!(f, "ExecutorError"),
+            }
+        }
+    }
+
+    pub(crate) struct TestFuture {
+        work: usize,
+        poll_count: usize,
+        error_after_n_polls: Option<usize>,
+    }
+
+    impl TestFuture {
+        pub(crate) fn new(work: usize) -> Self {
+            Self {
+                work,
+                error_after_n_polls: None,
+                poll_count: 0,
+            }
+        }
+
+        pub(crate) fn new_with_err(work: usize, poll_count: usize) -> Self {
+            Self {
+                work,
+                error_after_n_polls: Some(poll_count),
+                poll_count: 0,
+            }
+        }
+
+        /// 0 means immediately
+        pub(crate) fn error_after(&mut self, poll_count: usize) {
+            self.error_after_n_polls = Some(poll_count)
+        }
+    }
+
+    impl Future for TestFuture {
+        type Output = TestFutureResponse;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.poll_count += 1;
+
+            if let Some(poll_count) = self.error_after_n_polls {
+                if poll_count < self.poll_count {
+                    return Poll::Ready(TestFutureResponse::InnerError(self.poll_count));
+                }
+            }
+
+            self.work -= 1;
+            match self.work {
+                remaining if remaining > 0 => {
+                    // tell executor to immediately poll us again,
+                    // which passes through our vacation future as well
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                _ => Poll::Ready(TestFutureResponse::Success(self.poll_count)),
+            }
+        }
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -123,7 +123,8 @@ pub enum WhileWaitingMode {
 ///                 .offload_future(vacation::execute(
 ///                      // the work to offload
 ///                     || std::thread::sleep(std::time::Duration::from_millis(100)),
-///                     vacation::ChanceOfBlocking::High
+///                     vacation::ChanceOfBlocking::High,
+///                     "test.operation"
 ///                 ))
 ///                 // accepts the result of offloaded work, and returns an erorr
 ///                 // or an inner future
@@ -163,7 +164,8 @@ pub enum WhileWaitingMode {
 ///                     // it could be conditional, but here it's always returning work
 ///                     Ok(Some(Box::pin(vacation::execute(
 ///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
-///                         vacation::ChanceOfBlocking::High
+///                         vacation::ChanceOfBlocking::High,
+///                         "test.operation"
 ///                     ))))
 ///                 })
 ///                 // called with the results of the offloaded work and the inner future,

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -161,10 +161,10 @@ pub enum WhileWaitingMode {
 ///                 // and retrieve any work to offload
 ///                 .get_offload_fn(|_inner_fut| {
 ///                     // it could be conditional, but here it's always returning work
-///                     Ok(Some(Box::new(Box::pin(vacation::execute(
+///                     Ok(Some(Box::pin(vacation::execute(
 ///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
 ///                         vacation::ChanceOfBlocking::High
-///                     )))))
+///                     ))))
 ///                 })
 ///                 // called with the results of the offloaded work and the inner future,
 ///                 // use to convert errors or do any post-processing

--- a/src/future/with.rs
+++ b/src/future/with.rs
@@ -44,7 +44,8 @@ pin_project! {
 ///                     // it could be conditional, but here it's always returning work
 ///                     Ok(Some(Box::pin(vacation::execute(
 ///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
-///                         vacation::ChanceOfBlocking::High
+///                         vacation::ChanceOfBlocking::High,
+///                         "test.operation"
 ///                     ))))
 ///                 })
 ///                 // called with the results of the offloaded work and the inner future,
@@ -87,7 +88,8 @@ pub struct OffloadWithFuture<InnerFut, GetOffloadFn, OffloadResult, IncorporateF
 ///          // it could be conditional, but here it's always returning work
 ///          Ok(Some(Box::pin(vacation::execute(
 ///              || std::thread::sleep(std::time::Duration::from_millis(50)),
-///              vacation::ChanceOfBlocking::High
+///              vacation::ChanceOfBlocking::High,
+///              "test.operation"
 ///          ))))
 ///      })
 ///      .incorporate_fn(|_inner_fut: &mut InnerFut, res: Result<bool, vacation::Error>| {
@@ -136,7 +138,8 @@ impl FutureBuilder<NeedsStrategy, NeedsInnerFuture, NeedsOffload, NeedsWhileWait
     ///                     // it could be conditional, but here it's always returning work
     ///                     Ok(Some(Box::pin(vacation::execute(
     ///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
-    ///                         vacation::ChanceOfBlocking::High
+    ///                         vacation::ChanceOfBlocking::High,
+    ///                         "test.operation"
     ///                     ))))
     ///                 })
     ///                 // called with the results of the offloaded work and the inner future,
@@ -210,7 +213,8 @@ impl<IncorporateFn> OffloadWith<NeedsGetOffloadFn, IncorporateFn> {
     ///          // it could be conditional, but here it's always returning work
     ///          Ok(Some(Box::pin(vacation::execute(
     ///              || std::thread::sleep(std::time::Duration::from_millis(50)),
-    ///              vacation::ChanceOfBlocking::High
+    ///              vacation::ChanceOfBlocking::High,
+    ///              "test.operation"
     ///          ))))
     ///      });
     /// # }
@@ -259,7 +263,8 @@ impl<GetOffloadFn> OffloadWith<GetOffloadFn, NeedsIncorporateFn> {
     ///          // it could be conditional, but here it's always returning work
     ///          Ok(Some(Box::pin(vacation::execute(
     ///              || std::thread::sleep(std::time::Duration::from_millis(50)),
-    ///              vacation::ChanceOfBlocking::High
+    ///              vacation::ChanceOfBlocking::High,
+    ///              "test.operation"
     ///          ))))
     ///      })
     ///      .incorporate_fn(|_inner_fut: &mut InnerFut, res: Result<bool, vacation::Error>| {
@@ -520,7 +525,7 @@ mod test {
                         Ok(())
                     };
 
-                    let offload_fut = crate::execute(closure, ChanceOfBlocking::High);
+                    let offload_fut = crate::execute(closure, ChanceOfBlocking::High, "test.operation");
 
                     Ok(Some(Box::pin(offload_fut)))
                 })
@@ -749,6 +754,7 @@ mod test {
                         Ok(Some(Box::pin(crate::execute(
                             || std::thread::sleep(Duration::from_millis(50)),
                             ChanceOfBlocking::High,
+                            "test.operation",
                         ))))
                     })
                     .incorporate_fn(|_: &mut TestFuture, _: Result<(), crate::Error>| {

--- a/src/future/with.rs
+++ b/src/future/with.rs
@@ -736,6 +736,9 @@ mod test {
         assert_eq!(0, work_rx.len());
     }
 
+    // we test suppressing the inner poll in the integ tests, since we can't block
+    // and return pending without spawn_blocking strategy
+
     #[tokio::test]
     async fn supress_inner_poll_works() {
         // 2 units of work means one poll, then we get work, and then next poll we finish...

--- a/src/future/with.rs
+++ b/src/future/with.rs
@@ -1,0 +1,772 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+
+use super::{
+    FutureBuilder, HasIncorporateFn, NeedsIncorporateFn, NeedsInnerFuture, NeedsOffload,
+    NeedsStrategy, NeedsWhileWaiting, OffloadWithFutureStrat, WhileWaitingMode,
+};
+
+pin_project! {
+///  Wrapper future that processes occasional work offloaded from the inner future, while driving the inner future.
+///
+/// The order of execution is:
+/// - poll any active vacation work
+///     - if work completes, the incorporate fn to resolve it (includes mutable pointer to inner task + result of vacation)
+/// - poll inner future (if either [`WhileWaitingMode::PassThroughInnerPoll`], or no active offloaded work
+/// - poll to see if there is any vacation work to prepare (if no work is already active)
+///     - if there is, poll it once and then call the incorporate fn with its results if complete
+///
+/// Returning an error in any vacation handling (getting work, incorporating the results of work)
+/// will abort the inner future and bubble up. But, you can also discard errors to make these
+/// calls infallible.
+///
+/// # Examples
+///
+/// ```
+/// # #[tokio::main]
+/// # async fn main() {
+/// let future = vacation::future::builder()
+///          // the wrapped future
+///         .future(Box::pin( async move {
+///             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+///             true
+///         }))
+///         .offload_with(
+///             vacation::future::OffloadWith::builder()
+///                 // take a mutable reference to inner future,
+///                 // and retrieve any work to offload
+///                 .get_offload_fn(|_inner_fut| {
+///                     // it could be conditional, but here it's always returning work
+///                     Ok(Some(Box::new(Box::pin(vacation::execute(
+///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
+///                         vacation::ChanceOfBlocking::High
+///                     )))))
+///                 })
+///                 // called with the results of the offloaded work and the inner future,
+///                 // use to convert errors or do any post-processing
+///                 .incorporate_fn(|_inner_fut, res| {
+///                     println!("work complete: {res:#?}");
+///                     Ok(())
+///                 })
+///         )
+///         // could also suppress the inner poll
+///         .while_waiting_for_offload(vacation::future::WhileWaitingMode::PassThroughInnerPoll)
+///         .build();
+///
+/// assert_eq!(future.await, true)
+/// # }
+/// ```
+/// [`WhileWaitingMode::PassThroughInnerPoll`]: crate::future::WhileWaitingMode::PassThroughInnerPoll
+pub struct OffloadWithFuture<InnerFut, GetOffloadFn, OffloadResult, IncorporateFn> {
+    inner_fut: InnerFut,
+    get_offload_fn: GetOffloadFn,
+    incorporate_fn: IncorporateFn,
+    offload_fut: Option<Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>>,
+    while_waiting: WhileWaitingMode,
+}
+}
+
+#[derive(Debug)]
+/// A sub-builder for work to be offloaded via [`OffloadWithFuture`]
+///
+/// # Examples
+///
+/// ```
+/// # type InnerFut = Box<std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>>;
+/// # #[tokio::main]
+/// # async fn run() {
+/// let builder = vacation::future::OffloadWith::builder()
+///      // take a mutable reference to inner future,
+///      // and retrieve any work to offload
+///      .get_offload_fn(|_inner_fut: &mut InnerFut| {
+///          // it could be conditional, but here it's always returning work
+///          Ok(Some(Box::new(Box::pin(vacation::execute(
+///              || std::thread::sleep(std::time::Duration::from_millis(50)),
+///              vacation::ChanceOfBlocking::High
+///          )))))
+///      })
+///      .incorporate_fn(|_inner_fut: &mut InnerFut, res: Result<bool, vacation::Error>| {
+///           println!("work complete: {res:#?}");
+///           Ok(())
+///       });
+/// # }
+/// ```
+pub struct OffloadWith<GetOffloadFn, IncorporateFn> {
+    get_offload_fn: GetOffloadFn,
+    incorporate_fn: IncorporateFn,
+}
+
+// this is the builder impl that splits into together or initialize builders
+impl FutureBuilder<NeedsStrategy, NeedsInnerFuture, NeedsOffload, NeedsWhileWaiting> {
+    #[must_use = "doesn't do anything unless built"]
+    ///  Accepts an inner future to wrap with [`OffloadWithFuture`]
+    ///
+    /// The order of execution is:
+    /// - poll any active vacation work
+    ///     - if work completes, the incorporate fn to resolve it (includes mutable pointer to inner task + result of vacation)
+    /// - poll inner future (if either [`WhileWaitingMode::PassThroughInnerPoll`], or no active offloaded work
+    /// - poll to see if there is any vacation work to prepare (if no work is already active)
+    ///     - if there is, poll it once and then call the incorporate fn with its results if complete
+    ///
+    /// Returning an error in any vacation handling (getting work, incorporating the results of work)
+    /// will abort the inner future and bubble up. But, you can also discard errors to make these
+    /// calls infallible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let future = vacation::future::builder()
+    ///          // the wrapped future
+    ///         .future(Box::pin( async move {
+    ///             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    ///             true
+    ///         }))
+    ///         .offload_with(
+    ///             vacation::future::OffloadWith::builder()
+    ///                 // take a mutable reference to inner future,
+    ///                 // and retrieve any work to offload
+    ///                 .get_offload_fn(|_inner_fut| {
+    ///                     // it could be conditional, but here it's always returning work
+    ///                     Ok(Some(Box::new(Box::pin(vacation::execute(
+    ///                         || std::thread::sleep(std::time::Duration::from_millis(50)),
+    ///                         vacation::ChanceOfBlocking::High
+    ///                     )))))
+    ///                 })
+    ///                 // called with the results of the offloaded work and the inner future,
+    ///                 // use to convert errors or do any post-processing
+    ///                 .incorporate_fn(|_inner_fut, res| {
+    ///                     println!("work complete: {res:#?}");
+    ///                     Ok(())
+    ///                 })
+    ///         )
+    ///         // could also suppress the inner poll
+    ///         .while_waiting_for_offload(vacation::future::WhileWaitingMode::PassThroughInnerPoll)
+    ///         .build();
+    ///
+    /// assert_eq!(future.await, true)
+    /// # }
+    /// ```
+    /// [`WhileWaitingMode::PassThroughInnerPoll`]: crate::future::WhileWaitingMode::PassThroughInnerPoll
+    /// [`OffloadWith`]: crate::future::with::OffloadWithFuture
+    pub fn future<InnerFut>(
+        self,
+        inner_fut: InnerFut,
+    ) -> FutureBuilder<OffloadWithFutureStrat, InnerFut, NeedsOffload, NeedsWhileWaiting>
+    where
+        InnerFut: Future + Unpin,
+    {
+        FutureBuilder::<OffloadWithFutureStrat, InnerFut, NeedsOffload, NeedsWhileWaiting> {
+            strategy: OffloadWithFutureStrat,
+            inner_fut,
+            offload: NeedsOffload,
+            while_waiting: NeedsWhileWaiting,
+        }
+    }
+}
+
+/// The sub-builder still needs a call to [`get_offload_fn()`]
+///
+/// [`get_offload_fn()`]: crate::future::with::OffloadWith::get_offload_fn()
+#[derive(Debug)]
+pub struct NeedsGetOffloadFn;
+/// Sub-builder has a get offload function loaded
+#[derive(Debug)]
+pub struct HasGetOffloadFn<GetOffloadFn>(GetOffloadFn);
+
+impl OffloadWith<NeedsGetOffloadFn, NeedsIncorporateFn> {
+    /// docs
+    #[must_use = "doesn't do anything unless built"]
+    pub fn builder() -> OffloadWith<NeedsGetOffloadFn, NeedsIncorporateFn> {
+        OffloadWith {
+            get_offload_fn: NeedsGetOffloadFn,
+            incorporate_fn: NeedsIncorporateFn,
+        }
+    }
+}
+
+impl<IncorporateFn> OffloadWith<NeedsGetOffloadFn, IncorporateFn> {
+    /// A function to call after polling the inner future, to see
+    /// if any work is available. Returns the offloaded work future,
+    /// already passed into [`vacation::execute()`].
+    ///
+    /// This will generally require that you wrap the work in `Box::new(Box::pin())`.
+    ///
+    /// # Examples
+    /// ```
+    /// # type InnerFut = Box<std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>>;
+    /// # #[tokio::main]
+    /// # async fn run() {
+    /// let builder = vacation::future::OffloadWith::builder()
+    ///      // take a mutable reference to inner future,
+    ///      // and retrieve any work to offload
+    ///      .get_offload_fn(|_inner_fut: &mut InnerFut| {
+    ///          // it could be conditional, but here it's always returning work
+    ///          Ok(Some(Box::new(Box::pin(vacation::execute(
+    ///              || std::thread::sleep(std::time::Duration::from_millis(50)),
+    ///              vacation::ChanceOfBlocking::High
+    ///          )))))
+    ///      });
+    /// # }
+    /// ```
+    ///
+    /// [`vacation::execute()`]: crate::execute()
+    #[must_use = "doesn't do anything unless built"]
+    pub fn get_offload_fn<GetOffloadFn, OffloadResult, InnerFut>(
+        self,
+        get_offload_fn: GetOffloadFn,
+    ) -> OffloadWith<HasGetOffloadFn<GetOffloadFn>, IncorporateFn>
+    where
+        GetOffloadFn: Fn(
+            &mut InnerFut,
+        ) -> Result<
+            Option<Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>>,
+            InnerFut::Output,
+        >,
+        OffloadResult: Send + 'static,
+        InnerFut: Future + Unpin,
+    {
+        OffloadWith {
+            get_offload_fn: HasGetOffloadFn(get_offload_fn),
+            incorporate_fn: self.incorporate_fn,
+        }
+    }
+}
+
+impl<GetOffloadFn> OffloadWith<GetOffloadFn, NeedsIncorporateFn> {
+    /// A function to call with the result of the offloaded work,
+    /// to handle executor errors and do any post processing.
+    ///
+    /// Errors returned by this function will be bubbled up, aborting
+    /// the inner future.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # type InnerFut = Box<std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>>;
+    /// # #[tokio::main]
+    /// # async fn run() {
+    /// let builder = vacation::future::OffloadWith::builder()
+    ///      // take a mutable reference to inner future,
+    ///      // and retrieve any work to offload
+    ///      .get_offload_fn(|_inner_fut: &mut InnerFut| {
+    ///          // it could be conditional, but here it's always returning work
+    ///          Ok(Some(Box::new(Box::pin(vacation::execute(
+    ///              || std::thread::sleep(std::time::Duration::from_millis(50)),
+    ///              vacation::ChanceOfBlocking::High
+    ///          )))))
+    ///      })
+    ///      .incorporate_fn(|_inner_fut: &mut InnerFut, res: Result<bool, vacation::Error>| {
+    ///           println!("work complete: {res:#?}");
+    ///           Ok(())
+    ///       });
+    /// # }
+    /// ```
+    #[must_use = "doesn't do anything unless built"]
+    pub fn incorporate_fn<IncorporateFn, OffloadResult, InnerFut>(
+        self,
+        incorporate_fn: IncorporateFn,
+    ) -> OffloadWith<GetOffloadFn, HasIncorporateFn<IncorporateFn>>
+    where
+        IncorporateFn:
+            Fn(&mut InnerFut, Result<OffloadResult, crate::Error>) -> Result<(), InnerFut::Output>,
+        OffloadResult: Send + 'static,
+        InnerFut: Future + Unpin,
+    {
+        OffloadWith {
+            get_offload_fn: self.get_offload_fn,
+            incorporate_fn: HasIncorporateFn(incorporate_fn),
+        }
+    }
+}
+
+impl<InnerFut, WhileWaiting>
+    FutureBuilder<OffloadWithFutureStrat, InnerFut, NeedsOffload, WhileWaiting>
+{
+    /// Accepts an [`OffloadWith`] builder with a get offload function loaded, as well
+    /// as an optional incorporator function
+    #[must_use = "doesn't do anything unless built"]
+    pub fn offload_with<GetOffloadFn, IncorporateFn>(
+        self,
+        offload: OffloadWith<HasGetOffloadFn<GetOffloadFn>, IncorporateFn>,
+    ) -> FutureBuilder<
+        OffloadWithFutureStrat,
+        InnerFut,
+        OffloadWith<HasGetOffloadFn<GetOffloadFn>, IncorporateFn>,
+        WhileWaiting,
+    >
+    where
+        InnerFut: Future + Unpin,
+    {
+        FutureBuilder::<
+            OffloadWithFutureStrat,
+            InnerFut,
+            OffloadWith<HasGetOffloadFn<GetOffloadFn>, IncorporateFn>,
+            WhileWaiting,
+        > {
+            strategy: self.strategy,
+            inner_fut: self.inner_fut,
+            offload,
+            while_waiting: self.while_waiting,
+        }
+    }
+}
+
+impl<InnerFut, Offload>
+    FutureBuilder<OffloadWithFutureStrat, InnerFut, Offload, NeedsWhileWaiting>
+{
+    /// Specify behavior while vacation work is being actively driven.
+    ///
+    /// Either skip polling the inner until vacation work is complete,
+    /// or continue polling the inner future alongside
+    /// the vacation future.
+    ///
+    /// If using [`WhileWaitingMode::SuppressInnerPoll`], note that there is a deadlock risk of the offloaded
+    /// work completion relies on the inner future making progress.
+    #[must_use = "doesn't do anything unless built"]
+    pub fn while_waiting_for_offload(
+        self,
+        while_waiting: WhileWaitingMode,
+    ) -> FutureBuilder<OffloadWithFutureStrat, InnerFut, Offload, WhileWaitingMode>
+    where
+        InnerFut: Future + Unpin,
+    {
+        FutureBuilder::<OffloadWithFutureStrat, InnerFut, Offload, WhileWaitingMode> {
+            strategy: self.strategy,
+            inner_fut: self.inner_fut,
+            offload: self.offload,
+            while_waiting,
+        }
+    }
+}
+
+impl<InnerFut, GetOffloadFn, IncorporateFn>
+    FutureBuilder<
+        OffloadWithFutureStrat,
+        InnerFut,
+        OffloadWith<HasGetOffloadFn<GetOffloadFn>, HasIncorporateFn<IncorporateFn>>,
+        WhileWaitingMode,
+    >
+{
+    #[must_use = "doesn't do anything unless polled"]
+    /// Finish building [`OffloadWithFuture`]
+    pub fn build<OffloadResult>(
+        self,
+    ) -> OffloadWithFuture<InnerFut, GetOffloadFn, OffloadResult, IncorporateFn> {
+        OffloadWithFuture {
+            inner_fut: self.inner_fut,
+            get_offload_fn: self.offload.get_offload_fn.0,
+            incorporate_fn: self.offload.incorporate_fn.0,
+            offload_fut: None,
+            while_waiting: self.while_waiting,
+        }
+    }
+}
+
+impl<InnerFut: Future, GetOffloadFn, OffloadResult, IncorporateFn>
+    OffloadWithFuture<InnerFut, GetOffloadFn, OffloadResult, IncorporateFn>
+{
+    /// Helper fn to poll the offloaded future and call its incorporator as needed
+    ///
+    /// Updates self to store the future again if it's not complete
+    fn poll_offloaded_work(
+        &mut self,
+        mut offload_fut: Box<
+            dyn Future<Output = Result<OffloadResult, crate::Error>> + Send + Unpin,
+        >,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), InnerFut::Output>>
+    where
+        IncorporateFn:
+            Fn(&mut InnerFut, Result<OffloadResult, crate::Error>) -> Result<(), InnerFut::Output>,
+    {
+        if let Poll::Ready(res) = Pin::new(&mut offload_fut).poll(cx) {
+            // if work completes, call the incorporate function with it
+            match (self.incorporate_fn)(&mut self.inner_fut, res) {
+                Ok(()) => Poll::Ready(Ok(())),
+                // bubble any errors up
+                Err(err) => Poll::Ready(Err(err)),
+            }
+        } else {
+            self.offload_fut = Some(offload_fut);
+            Poll::Pending
+        }
+    }
+}
+
+impl<InnerFut, GetOffloadFn, OffloadResult, IncorporateFn> Future
+    for OffloadWithFuture<InnerFut, GetOffloadFn, OffloadResult, IncorporateFn>
+where
+    InnerFut: Future + Unpin,
+    GetOffloadFn: Fn(
+        &mut InnerFut,
+    ) -> Result<
+        Option<Box<dyn Future<Output = Result<OffloadResult, crate::Error>> + Unpin + Send>>,
+        InnerFut::Output,
+    >,
+    OffloadResult: Send + 'static,
+    IncorporateFn:
+        Fn(&mut InnerFut, Result<OffloadResult, crate::Error>) -> Result<(), InnerFut::Output>,
+{
+    type Output = InnerFut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // first execute any vacation work
+        if let Some(offload_fut) = this.offload_fut.take() {
+            match this.poll_offloaded_work(offload_fut, cx) {
+                // if we are done, clean up state
+                Poll::Ready(Ok(())) => this.offload_fut = None,
+                // bubble up any errors
+                Poll::Ready(Err(err)) => return Poll::Ready(err),
+                _ => (),
+            }
+        }
+
+        if this.offload_fut.is_none()
+            || this.while_waiting == WhileWaitingMode::PassThroughInnerPoll
+        {
+            if let Poll::Ready(res) = Pin::new(&mut this.inner_fut).poll(cx) {
+                // if inner is ready, we drop any active vacation work (at least on this task's side) and return inner's result
+                return Poll::Ready(res);
+            }
+        }
+
+        // we only prepare new vacation work if there is none loaded already
+        // TODO: consider allowing a vec of multiple work units
+        if this.offload_fut.is_none() {
+            match (this.get_offload_fn)(&mut this.inner_fut) {
+                // bubble up any errors
+                Err(err) => return Poll::Ready(err),
+                Ok(Some(offload_fut)) => {
+                    // poll the work once and bubble up any errors
+                    // poll_offloaded_work updates the state for us if the offloaded future is still pending
+                    if let Poll::Ready(Err(err)) = this.poll_offloaded_work(offload_fut, cx) {
+                        return Poll::Ready(err);
+                    }
+                }
+                // no work = do nothing
+                _ => (),
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+// these tests all use the default executor which is `ExecuteDirectly`
+#[cfg(test)]
+mod test {
+    use std::{future::Future, time::Duration};
+
+    use tokio::sync::mpsc::Sender;
+
+    use crate::{
+        future::{
+            test::{TestFuture, TestFutureResponse},
+            WhileWaitingMode,
+        },
+        ChanceOfBlocking,
+    };
+
+    use super::{OffloadWith, OffloadWithFuture};
+
+    /// Wraps a [`TestFuture`] in vacation handling
+    /// to send to a mpsc channel each stage's call, or
+    /// return an error if that channel is dropped.
+    fn vacation_fut(
+        inner_fut: TestFuture,
+        get_tx: Sender<()>,
+        work_tx: Sender<()>,
+        incorporate_tx: Sender<()>,
+        while_waiting: WhileWaitingMode,
+    ) -> OffloadWithFuture<
+        TestFuture,
+        impl Fn(
+            &mut TestFuture,
+        ) -> Result<
+            Option<
+                Box<
+                    dyn Future<Output = Result<Result<(), TestFutureResponse>, crate::Error>>
+                        + Unpin
+                        + Send,
+                >,
+            >,
+            TestFutureResponse,
+        >,
+        Result<(), TestFutureResponse>,
+        impl Fn(
+            &mut TestFuture,
+            Result<Result<(), TestFutureResponse>, crate::Error>,
+        ) -> Result<(), TestFutureResponse>,
+    > {
+        crate::future::builder()
+            .future(inner_fut)
+            .offload_with(
+                OffloadWith::builder()
+                .get_offload_fn(move |_| {
+                    if get_tx.clone().try_send(()).is_err() {
+                        return Err(TestFutureResponse::VacationGetError);
+                    }
+
+                    let tx = work_tx.clone();
+                    let closure = move || {
+                        if tx.try_send(()).is_err() {
+                            return Err(TestFutureResponse::VacationWorkError);
+                        }
+                        Ok(())
+                    };
+
+                    let offload_fut = crate::execute(closure, ChanceOfBlocking::High);
+
+                    Ok(Some(Box::new(Box::pin(offload_fut))))
+                })
+                .incorporate_fn(
+                    move |_inner: &mut TestFuture,
+                    res: Result<Result<(), TestFutureResponse>, crate::Error>| {
+                  if res.is_err() {
+                      return Err(TestFutureResponse::ExecutorError);
+                  }
+
+                  if res.unwrap().is_err() {
+                      return Err(TestFutureResponse::VacationWorkError);
+                  }
+
+                  if incorporate_tx.clone().try_send(()).is_err() {
+                      return Err(TestFutureResponse::VacationIncorporateError);
+                  }
+
+                  Ok(())
+                }
+                )
+            )
+            .while_waiting_for_offload(while_waiting)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn it_works() {
+        let inner_fut = TestFuture::new(3);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        let res = future.await;
+
+        // gets work on first poll,
+        // executes work on second poll + gets more work
+        // executes work on third poll, then finishes inner future and returns before getting more work
+        assert_eq!(res, TestFutureResponse::Success(3));
+        assert_eq!(2, get_rx.len());
+        assert_eq!(2, work_rx.len());
+        assert_eq!(2, incorporate_rx.len());
+    }
+
+    #[tokio::test]
+    async fn inner_error() {
+        let inner_fut = TestFuture::new_with_err(3, 0);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        let res = future.await;
+        //
+
+        // first poll fails, no work picked up or executed
+        assert_eq!(res, TestFutureResponse::InnerError(1));
+        assert_eq!(0, get_rx.len());
+        assert_eq!(0, work_rx.len());
+        assert_eq!(0, incorporate_rx.len());
+    }
+
+    #[tokio::test]
+    async fn delayed_inner_error() {
+        let inner_fut = TestFuture::new_with_err(3, 1);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        let res = future.await;
+
+        // first poll succeeds, new work from get
+        // vacation work executes and resolves, then inner poll fails, no new get
+        assert_eq!(res, TestFutureResponse::InnerError(2));
+        assert_eq!(1, get_rx.len());
+        assert_eq!(1, work_rx.len());
+        assert_eq!(1, incorporate_rx.len());
+    }
+
+    #[tokio::test]
+    async fn incorporate_err() {
+        let inner_fut: TestFuture = TestFuture::new(3);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        std::mem::drop(incorporate_rx);
+
+        let res = future.await;
+
+        // first poll succeeds and gathers new work
+        // execute work succeeds, then resolve fails
+        assert_eq!(res, TestFutureResponse::VacationIncorporateError);
+        assert_eq!(1, get_rx.len());
+        assert_eq!(1, work_rx.len());
+    }
+
+    #[tokio::test]
+    async fn work_err() {
+        let inner_fut: TestFuture = TestFuture::new(2);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        std::mem::drop(work_rx);
+
+        let res = future.await;
+
+        // first poll succeeds and gathers new work
+        // then execute fails
+        assert_eq!(res, TestFutureResponse::VacationWorkError);
+        assert_eq!(1, get_rx.len());
+        assert_eq!(0, incorporate_rx.len());
+    }
+
+    #[tokio::test]
+    async fn work_err_but_inner_ready() {
+        let inner_fut: TestFuture = TestFuture::new(1);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        std::mem::drop(work_rx);
+
+        let res = future.await;
+
+        // first poll succeeds so we never get or execute the failing work
+        assert_eq!(res, TestFutureResponse::Success(1));
+        assert_eq!(0, get_rx.len());
+        assert_eq!(0, incorporate_rx.len());
+    }
+
+    #[tokio::test]
+    async fn get_err() {
+        let inner_fut: TestFuture = TestFuture::new(2);
+
+        let (get_tx, get_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (work_tx, work_rx) = tokio::sync::mpsc::channel::<()>(5);
+        let (incorporate_tx, incorporate_rx) = tokio::sync::mpsc::channel::<()>(5);
+
+        let future = vacation_fut(
+            inner_fut,
+            get_tx,
+            work_tx,
+            incorporate_tx,
+            WhileWaitingMode::PassThroughInnerPoll,
+        );
+
+        std::mem::drop(get_rx);
+
+        let res = future.await;
+
+        // first poll succeeds and then get work fails
+        assert_eq!(res, TestFutureResponse::VacationGetError);
+        assert_eq!(0, incorporate_rx.len());
+        assert_eq!(0, work_rx.len());
+    }
+
+    #[tokio::test]
+    async fn supress_inner_poll_works() {
+        // 2 units of work means one poll, then we get work, and then next poll we finish...
+        // except that we suppress inner poll, so vacation finishes first despite being slower
+        let inner_fut = TestFuture::new(3);
+
+        let future = crate::future::builder()
+            .future(inner_fut)
+            .offload_with(
+                OffloadWith::builder()
+                    .get_offload_fn(|_: &mut TestFuture| {
+                        Ok(Some(Box::new(Box::pin(crate::execute(
+                            || std::thread::sleep(Duration::from_millis(50)),
+                            ChanceOfBlocking::High,
+                        )))))
+                    })
+                    .incorporate_fn(|_: &mut TestFuture, _: Result<(), crate::Error>| {
+                        Err(TestFutureResponse::VacationIncorporateError)
+                    }),
+            )
+            .while_waiting_for_offload(WhileWaitingMode::SuppressInnerPoll)
+            .build::<()>();
+
+        let res = future.await;
+
+        // if the inner future completed, we would have success, but instead we delay polling and return
+        // an error after the slower vacation work finishes
+
+        // gets work on first poll,
+        // executes work on second poll + gets more work
+        // executes work on third poll, then finishes inner future and returns before getting more work
+        assert_eq!(res, TestFutureResponse::VacationIncorporateError);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use executor::{
     global_strategy, ExecutorBuilder,
 };
 
-use executor::{get_global_executor, Execute, Executor, NeedsStrategy};
+use executor::{get_global_executor, Executor, NeedsStrategy};
 
 /// The currently loaded global strategy.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,19 @@
 mod concurrency_limit;
 mod error;
 mod executor;
+#[cfg(feature = "future")]
+/// Vacation future implementations for libraries that are manually implementing futures
+pub mod future;
 
 pub use error::Error;
+#[cfg(feature = "tokio")]
+pub use executor::install_tokio_strategy;
 pub use executor::{
     custom::{CustomClosureInput, CustomClosureOutput},
-    global_strategy, install_tokio_strategy, ExecutorBuilder,
+    global_strategy, ExecutorBuilder,
 };
 
 use executor::{get_global_executor, Execute, Executor, NeedsStrategy};
-
-use std::fmt::Debug;
 
 /// The currently loaded global strategy.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -41,10 +44,6 @@ pub enum GlobalStrategy {
 ///
 /// # fn run() {
 ///
-/// #[cfg(feature = "tokio")]
-/// assert_eq!(global_strategy(), GlobalStrategy::Default(ExecutorStrategy::SpawnBlocking));
-///
-/// #[cfg(not(feature = "tokio"))]
 /// assert_eq!(global_strategy(), GlobalStrategy::Default(ExecutorStrategy::ExecuteDirectly));
 ///
 /// vacation::init()
@@ -77,7 +76,7 @@ pub enum ExecutorStrategy {
 ///
 /// ```
 /// # fn run() {
-/// vacation::init().max_concurrency(3).spawn_blocking().install().unwrap();
+/// vacation::init().max_concurrency(3).execute_directly().install().unwrap();
 /// # }
 /// ```
 #[must_use = "doesn't do anything unless used"]

--- a/tests/custom_simple.rs
+++ b/tests/custom_simple.rs
@@ -7,9 +7,9 @@ use vacation::{
 
 #[tokio::test]
 async fn custom_simple() {
-    let custom_closure = |f: CustomClosureInput| {
+    let custom_closure = |input: CustomClosureInput| {
         Box::new(async move {
-            f();
+            (input.work)();
             Ok(())
         }) as CustomClosureOutput
     };
@@ -21,7 +21,9 @@ async fn custom_simple() {
         5
     };
 
-    let res = execute(closure, ChanceOfBlocking::High).await.unwrap();
+    let res = execute(closure, ChanceOfBlocking::High, "test.operation")
+        .await
+        .unwrap();
     assert_eq!(res, 5);
 
     assert_eq!(

--- a/tests/custom_strategy.rs
+++ b/tests/custom_strategy.rs
@@ -13,9 +13,9 @@ static THREADPOOL: OnceLock<ThreadPool> = OnceLock::new();
 async fn custom_concurrency() {
     THREADPOOL.get_or_init(|| rayon::ThreadPoolBuilder::default().build().unwrap());
 
-    let custom_closure = |f: CustomClosureInput| {
+    let custom_closure = |input: CustomClosureInput| {
         Box::new(async move {
-            THREADPOOL.get().unwrap().spawn(f);
+            THREADPOOL.get().unwrap().spawn(input.work);
             Ok(())
         }) as CustomClosureOutput
     };
@@ -42,7 +42,7 @@ async fn custom_concurrency() {
 
     // note that we also are racing against concurrency from other tests in this module
     for _ in 0..6 {
-        futures.push(execute(closure, ChanceOfBlocking::High));
+        futures.push(execute(closure, ChanceOfBlocking::High, "test.operation"));
     }
 
     let res = join_all(futures).await;

--- a/tests/custom_strategy.rs
+++ b/tests/custom_strategy.rs
@@ -2,11 +2,15 @@ use std::{sync::OnceLock, time::Duration};
 
 use futures_util::future::join_all;
 use rayon::ThreadPool;
-use vacation::{execute, init, ChanceOfBlocking, CustomClosureInput, CustomClosureOutput};
+use vacation::{
+    execute, init, ChanceOfBlocking, CustomClosureInput, CustomClosureOutput, ExecutorStrategy,
+    GlobalStrategy,
+};
 
 static THREADPOOL: OnceLock<ThreadPool> = OnceLock::new();
 
-fn initialize() {
+#[tokio::test]
+async fn custom_concurrency() {
     THREADPOOL.get_or_init(|| rayon::ThreadPoolBuilder::default().build().unwrap());
 
     let custom_closure = |f: CustomClosureInput| {
@@ -16,28 +20,16 @@ fn initialize() {
         }) as CustomClosureOutput
     };
 
-    let _ = init()
+    init()
         .max_concurrency(3)
         .custom_executor(custom_closure)
-        .install();
-}
+        .install()
+        .unwrap();
 
-#[tokio::test]
-async fn custom_strategy() {
-    initialize();
-
-    let closure = || {
-        std::thread::sleep(Duration::from_millis(15));
-        5
-    };
-
-    let res = execute(closure, ChanceOfBlocking::High).await.unwrap();
-    assert_eq!(res, 5);
-}
-
-#[tokio::test]
-async fn custom_concurrency() {
-    initialize();
+    assert_eq!(
+        vacation::global_strategy(),
+        GlobalStrategy::Initialized(ExecutorStrategy::Custom)
+    );
 
     let start = std::time::Instant::now();
 
@@ -47,17 +39,16 @@ async fn custom_concurrency() {
         std::thread::sleep(Duration::from_millis(15));
         5
     };
-    tokio::time::sleep(Duration::from_millis(5)).await;
 
     // note that we also are racing against concurrency from other tests in this module
     for _ in 0..6 {
         futures.push(execute(closure, ChanceOfBlocking::High));
     }
 
-    join_all(futures).await;
+    let res = join_all(futures).await;
 
     let elapsed_millis = start.elapsed().as_millis();
     assert!(elapsed_millis < 50, "futures did not run concurrently");
-
     assert!(elapsed_millis > 20, "futures exceeded max concurrency");
+    assert!(!res.iter().any(|res| res.is_err()));
 }

--- a/tests/execute_directly_default.rs
+++ b/tests/execute_directly_default.rs
@@ -11,7 +11,9 @@ async fn default_to_execute_directly() {
         5
     };
 
-    let res = execute(closure, ChanceOfBlocking::High).await.unwrap();
+    let res = execute(closure, ChanceOfBlocking::High, "test.operation")
+        .await
+        .unwrap();
     assert_eq!(res, 5);
 
     assert_eq!(
@@ -20,7 +22,9 @@ async fn default_to_execute_directly() {
     );
 
     // make sure we can continue to call it without failures due to repeat initialization
-    let res = execute(closure, ChanceOfBlocking::High).await.unwrap();
+    let res = execute(closure, ChanceOfBlocking::High, "test.operation")
+        .await
+        .unwrap();
     assert_eq!(res, 5);
 
     assert_eq!(

--- a/tests/execute_directly_strategy.rs
+++ b/tests/execute_directly_strategy.rs
@@ -31,7 +31,10 @@ async fn execute_directly() {
     for _ in 0..6 {
         // we need to spawn tasks since otherwise we'll just block the current worker thread
         let future = async move {
-            tokio::task::spawn(async move { execute(closure, ChanceOfBlocking::High).await }).await
+            tokio::task::spawn(async move {
+                execute(closure, ChanceOfBlocking::High, "test.operation").await
+            })
+            .await
         };
         futures.push(future);
     }

--- a/tests/offload_first.rs
+++ b/tests/offload_first.rs
@@ -1,0 +1,51 @@
+#[cfg(all(feature = "tokio", feature = "future"))]
+mod test {
+    use std::time::{Duration, Instant};
+
+    use futures_util::future::join_all;
+
+    #[tokio::test]
+    async fn offload_first() {
+        vacation::init()
+            .max_concurrency(3)
+            .spawn_blocking()
+            .install()
+            .unwrap();
+
+        let start = Instant::now();
+
+        let mut futures = Vec::new();
+
+        for _ in 0..6 {
+            let future = vacation::future::builder()
+                .offload_first(
+                    vacation::future::OffloadFirst::builder()
+                        .offload_future(vacation::execute(
+                            || {
+                                std::thread::sleep(Duration::from_millis(10));
+                                true
+                            },
+                            vacation::ChanceOfBlocking::High,
+                        ))
+                        .incorporate_fn(|res| {
+                            Ok(Box::pin(async move {
+                                tokio::time::sleep(Duration::from_millis(10)).await;
+                                res
+                            }))
+                        }),
+                )
+                .build();
+
+            futures.push(future);
+        }
+        let res = join_all(futures).await;
+        assert!(res.into_iter().all(|res| res.is_ok() && res.unwrap()));
+
+        let elapsed_millis = start.elapsed().as_millis();
+        assert!(
+            elapsed_millis < 60,
+            "futures did not run concurrently with each other"
+        );
+        assert!(elapsed_millis > 20, "futures exceeded max concurrency");
+    }
+}

--- a/tests/offload_first.rs
+++ b/tests/offload_first.rs
@@ -26,6 +26,7 @@ mod test {
                                 true
                             },
                             vacation::ChanceOfBlocking::High,
+                            "test.operation",
                         ))
                         .incorporate_fn(|res| {
                             Ok(Box::pin(async move {

--- a/tests/offload_with.rs
+++ b/tests/offload_with.rs
@@ -26,10 +26,10 @@ mod test {
                 .offload_with(
                     vacation::future::OffloadWith::builder()
                         .get_offload_fn(|_inner_fut| {
-                            Ok(Some(Box::new(Box::pin(vacation::execute(
+                            Ok(Some(Box::pin(vacation::execute(
                                 || std::thread::sleep(Duration::from_millis(20)),
                                 vacation::ChanceOfBlocking::High,
-                            )))))
+                            ))))
                         })
                         .incorporate_fn(|_, _| Ok(())),
                 )
@@ -49,17 +49,17 @@ mod test {
         assert!(elapsed_millis > 20, "futures exceeded max concurrency");
 
         let future = vacation::future::builder()
-            .future(Box::pin(async { 
+            .future(Box::pin(async {
                 tokio::time::sleep(Duration::from_millis(20)).await;
-                Ok::<bool, &'static str>(true) 
+                Ok::<bool, &'static str>(true)
             }))
             .offload_with(
                 vacation::future::OffloadWith::builder()
                     .get_offload_fn(|_| {
-                        Ok(Some(Box::new(Box::pin(vacation::execute(
+                        Ok(Some(Box::pin(vacation::execute(
                             || std::thread::sleep(Duration::from_millis(50)),
                             vacation::ChanceOfBlocking::High,
-                        )))))
+                        ))))
                     })
                     .incorporate_fn(|_, _: Result<(), vacation::Error>| Err(Err("foo"))),
             )

--- a/tests/offload_with.rs
+++ b/tests/offload_with.rs
@@ -1,0 +1,51 @@
+#[cfg(all(feature = "tokio", feature = "future"))]
+mod test {
+    use std::time::{Duration, Instant};
+
+    use futures_util::future::join_all;
+
+    #[tokio::test]
+    async fn offload_with() {
+        vacation::init()
+            .max_concurrency(3)
+            .spawn_blocking()
+            .install()
+            .unwrap();
+
+        let start = Instant::now();
+
+        let mut futures = Vec::new();
+
+        for _ in 0..6 {
+            let inner_future = Box::pin(async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                true
+            });
+            let future = vacation::future::builder()
+                .future(inner_future)
+                .offload_with(
+                    vacation::future::OffloadWith::builder()
+                        .get_offload_fn(|_inner_fut| {
+                            Ok(Some(Box::new(Box::pin(vacation::execute(
+                                || std::thread::sleep(Duration::from_millis(20)),
+                                vacation::ChanceOfBlocking::High,
+                            )))))
+                        })
+                        .incorporate_fn(|_, _| Ok(())),
+                )
+                .while_waiting_for_offload(vacation::future::WhileWaitingMode::PassThroughInnerPoll)
+                .build();
+
+            futures.push(future);
+        }
+        let res = join_all(futures).await;
+        assert!(res.iter().all(|res| *res));
+
+        let elapsed_millis = start.elapsed().as_millis();
+        assert!(
+            elapsed_millis < 60,
+            "inner fut did not run concurrently with work, and/or futures did not run concurrently with each other"
+        );
+        assert!(elapsed_millis > 20, "futures exceeded max concurrency");
+    }
+}

--- a/tests/offload_with.rs
+++ b/tests/offload_with.rs
@@ -29,6 +29,7 @@ mod test {
                             Ok(Some(Box::pin(vacation::execute(
                                 || std::thread::sleep(Duration::from_millis(20)),
                                 vacation::ChanceOfBlocking::High,
+                                "test.operation",
                             ))))
                         })
                         .incorporate_fn(|_, _| Ok(())),
@@ -59,6 +60,7 @@ mod test {
                         Ok(Some(Box::pin(vacation::execute(
                             || std::thread::sleep(Duration::from_millis(50)),
                             vacation::ChanceOfBlocking::High,
+                            "test.operation",
                         ))))
                     })
                     .incorporate_fn(|_, _: Result<(), vacation::Error>| Err(Err("foo"))),

--- a/tests/spawn_blocking_strategy.rs
+++ b/tests/spawn_blocking_strategy.rs
@@ -8,32 +8,19 @@ mod test {
         execute, global_strategy, init, ChanceOfBlocking, ExecutorStrategy, GlobalStrategy,
     };
 
-    fn initialize() {
-        // we are racing all tests against the single oncelock
-        let _ = init().max_concurrency(3).spawn_blocking().install();
-    }
-
     #[tokio::test]
-    async fn spawn_blocking_strategy() {
-        initialize();
-
-        let closure = || {
-            std::thread::sleep(Duration::from_millis(15));
-            5
-        };
-
-        let res = execute(closure, ChanceOfBlocking::High).await.unwrap();
-        assert_eq!(res, 5);
+    async fn spawn_blocking() {
+        init()
+            .max_concurrency(3)
+            .spawn_blocking()
+            .install()
+            .unwrap();
 
         assert_eq!(
             global_strategy(),
             GlobalStrategy::Initialized(ExecutorStrategy::SpawnBlocking)
         );
-    }
 
-    #[tokio::test]
-    async fn spawn_blocking_concurrency() {
-        initialize();
         let start = std::time::Instant::now();
 
         let mut futures = Vec::new();
@@ -48,14 +35,12 @@ mod test {
             let future = async move { execute(closure, ChanceOfBlocking::High).await };
             futures.push(future);
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
 
         let res = join_all(futures).await;
-        println!("{res:#?}");
 
         let elapsed_millis = start.elapsed().as_millis();
         assert!(elapsed_millis < 60, "futures did not run concurrently");
-
         assert!(elapsed_millis > 20, "futures exceeded max concurrency");
+        assert!(!res.iter().any(|res| res.is_err()));
     }
 }

--- a/tests/spawn_blocking_strategy.rs
+++ b/tests/spawn_blocking_strategy.rs
@@ -32,7 +32,8 @@ mod test {
 
         // note that we also are racing against concurrency from other tests in this module
         for _ in 0..6 {
-            let future = async move { execute(closure, ChanceOfBlocking::High).await };
+            let future =
+                async move { execute(closure, ChanceOfBlocking::High, "test.operation").await };
             futures.push(future);
         }
 


### PR DESCRIPTION
The highlight here is future module, with some other small stuff.

## Future module

Based on [initial usage in tokio-rustls](https://github.com/rustls/tokio-rustls/pull/99#issuecomment-2566140929), I want to expand this package to also include 'batteries' for libraries that are manually implementing futures. Since, needing to progressively poll vacation work before or alongside inner futures, is going to be a frequent use case. And, it takes a lot of intrusive boilerplate to manually implement it.

It's all optional under feature flag, though the only new dependency is `pin-project-lite`. LMK if you think I should remove the flag.

Currently I am targeting two use cases:
- do some compute-heavy work BEFORE starting to poll the future, in order to construct it 
   - in tokio-rustls, this means the initial handshake crypto work before our first network call
- do some compute-heavy work intermittently ALONGSIDE polling the inner future
     - in tokio-rustls, this means processing bytes that came in via I/O in order to generate the next crypto segment of a handshake

The first case is fairly simple. That is essentially just the [futures-util Then combinator](https://docs.rs/futures-util-preview/latest/futures_util/future/trait.FutureExt.html#method.then), with some convenience methods in the builder to construct the vacation work. I ended up rolling my own, but I'm happy to cut over to using futures-util if there are any issues with my impl.

The flow for `VacationFirst` is:
- construct the vacation work via a builder that accepts the sync work closure
- poll vacation work to completion on its own
- after work completes, call a FnOnce 'resolver' closure to process the results into the inner future, which might pull in other existing resources that aren't Send + 'static
- then just pass-through poll the inner future

The second case is a bit more complex. The constraint I'm operating in is, the inner future generally cannot be assumed to be fully composed of resources that are send + 'static. But, we do need access to certain elements of state derived from the inner future, both to generate the vacation work, and to handle the results of the vacation work.

We also would prefer to continue polling the inner future alongside the vacation future, since tokio-rustls's I/O work can sometimes proceed simultaneously. Anyway the inner future can always return `Poll::Pending` if it needs to wait on vacation.

The API I went with for `VacationOngoing`, is:
- Expose a hook in the inner future, so the vacation future can use a mutable pointer to call something like `inner_future.get_buffer_to_process_with_vacation()`. 
- Poll that hook after polling the inner future, using a closure to construct the vacation work (or surface an error)
    - That future doesn't have mutable access to the inner future, instead the closure can own any resources it needs
- If there is vacation work, also drive it every poll, surfacing any errors
- Once vacation work completes, call a 'resolver' closure in the same task as the inner future, which does any post-processing that needs mutable access to inner future

A couple notes:
- Currently we only support tracking one piece of vacation work at a time, that's what tokio-rustls needed. I can cut an issue to add support for multiple, it wouldn't be hard to add
- Currently I require that the caller sometimes `Box` things in the `VacationFirst` resolver closure or `VacationAlongside` get_work closure. I could do it for them, but often they need to return futures that already are sized and unpin, since they have defined them lower down. So it would have forced extra allocations to do it implicitly. Open to alternatives.

## Concurrency handling changes
I noticed an edge case in concurrency handling, where the calling future might drop (which holds the vacation executor handle to the sync work). The concurrency permit was acquired and dropped in the foreground, so concurrency would be released.

However, our vacation work isn't actually cancellable since we cut over to sync API, since it doesn't yield anywhere to drop work. So, the work could keep running after concurrency permit dropped, resulting in going beyond the limit.

Moving the permit drop to after the vacation work finishes, instead.

## Remove default features
The tokio default feature no longer seems sensible given that we don't implicitly update default strategies anyway. Just forces libraries to add `no-default-features = true`. Removing the implicit tokio default.

## Test improvements
My concurrency tests were occasionally failing, and I realized why - I was racing initializing the strategy against multiple test cases per integ test binary. Which, for spawn_blocking and some custom executor tests, implicitly is loading a specific runtime handle to use with the strategy.

And, that runtime ends when the test ends. Which, if it's not the concurrency test, will generally finish quicker than the concurreny test. This results in the listener channel closing and the vacation work getting cancelled, from the caller's perspective, and thus exceeds concurrency limit.

I also added an assertion that all vacation work actually succeeded, I was silently ignoring the cancellation related errors.

## Avoid async fn in trait
We had a trait definition for `execute()` that had a async function in it. Given that tokio-rustls supports 1.70, and AFIT is 1.75, I'd rather avoid forcing a MSRV bump to use vacation. We don't actually need the trait for anything since we are using enum dispatch anyway. Refactored to remove.

## Add operation namespace to `vacation::execute()`
Updated the `vacation::execute()` input to include an operation namespace, that is just a &'static str. This will open up a world of customizability without adding config drilling into the crate.

I focused on how it impacts the input end (as well as custom closure, since that was easy). I'll add richer support for customizing strategy based on this operation namespace (and chance of blocking), later.